### PR TITLE
Cmake revise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,94 +1,68 @@
 cmake_minimum_required(VERSION 3.6)
 project(chip_8)
 
-#Set C++ standard
-#make all warnings into compile time errors
-#use a memory leak dynamic (runtime) sanitizer to detect memory leaks.
-#Note: there seems to be memory leaks reported with some graphics and input drivers (ex: vmwgfx_dri - VMware's GL Driver, and libxi) that are out of this application's control
+# include custom cmake modules
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+include(add_external_static_cmake_library)
+
+# Set C++ standard
+# make all warnings into compile time errors
+# use a memory leak dynamic (runtime) sanitizer to detect memory leaks.
+# Note: there seems to be memory leaks reported with some graphics and input drivers (ex: vmwgfx_dri - VMware's GL Driver, and libxi) that are out of this application's control
 set(CMAKE_CXX_STANDARD 11)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=leak -fno-omit-frame-pointer -Werror -Wall -Wextra")
 
-#Setup different source file variables
+# Setup different source file variables
 set(SOURCE_FILES src/cpu/Cpu.cpp src/cpu/Cpu.h src/subsystems/display/IDisplay.h src/subsystems/input/IInputController.h src/storage/Memory.cpp src/storage/Memory.h src/exceptions/IndexOutOfBoundsException.h src/constants/Constants.h src/exceptions/InstructionUnimplementedException.h src/exceptions/BaseException.h src/constants/OpcodeBitmasks.h src/constants/Opcodes.h src/exceptions/UnimplementedException.h src/constants/OpcodeBitshifts.h src/utils/RandomUtil.cpp src/utils/RandomUtil.h src/io/FileByteReader.cpp src/io/FileByteReader.h src/exceptions/IOException.h src/exceptions/InitializationException.h src/subsystems/ISubsystemManager.h src/Chip8.cpp src/Chip8.h src/utils/SleepUtil.cpp src/utils/SleepUtil.h)
-#keep source files that are dependent on SDL library separate in order to exclude from testcases build (and possibly other builds in the future).
+# keep source files that are dependent on SDL library separate in order to exclude from testcases build (and possibly other builds in the future).
 set(SDL_SOURCE_FILES src/subsystems/display/Display.cpp src/subsystems/display/Display.h src/subsystems/input/InputController.cpp src/subsystems/input/InputController.h src/subsystems/SdlSubsystemManager.cpp src/subsystems/SdlSubsystemManager.h src/main.cpp)
 set(TESTING_SOURCE_FILES testcases/CpuTest.cpp testcases/CpuTestFixture.cpp testcases/CpuTestFixture.h ${SOURCE_FILES} testcases/main.cpp testcases/mocks/MockDisplay.h testcases/mocks/MockInputController.h)
 set(ALL_SOURCE_FILES ${SOURCE_FILES} ${SDL_SOURCE_FILES} ${TESTING_SOURCE_FILES})
 
-#Setup main emulator executable
-add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${SDL_SOURCE_FILES})
-
-#makefile target to run clang-format on all built files
-#See more at: https://arcanis.me/en/2015/10/17/cppcheck-and-clang-format#sthash.nl8UE5nB.dpuf
+# makefile target to run clang-format on all built files
+# See more at: https://arcanis.me/en/2015/10/17/cppcheck-and-clang-format#sthash.nl8UE5nB.dpuf
 add_custom_target(clangformat COMMAND cd .. && /usr/bin/clang-format -style=file -i ${ALL_SOURCE_FILES})
 
-#Required for both GTest and SDL2
+# Required for both GTest/GMock and SDL2 libraries
 find_package(Threads REQUIRED)
 
-#module required for including external projects (libraries)
-include(ExternalProject)
-
-#Setup SDL2 Library Dependencies
-ExternalProject_Add(
-        sdl2
-        URL https://www.libsdl.org/tmp/SDL-2.0.5-11113.zip
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/sdl2
-        INSTALL_COMMAND ""
-)
-ExternalProject_Get_Property(sdl2 SOURCE_DIR)
-ExternalProject_Get_Property(sdl2 BINARY_DIR)
-set(SDL2_SRC ${SOURCE_DIR})
-set(SDL2_BIN ${BINARY_DIR})
-add_library(libsdl2 IMPORTED STATIC GLOBAL)
+# Setup SDL2 Library
+add_external_static_cmake_library(libsdl2 https://www.libsdl.org/tmp/SDL-2.0.5-11113.zip libSDL2.a)
+#add sdl dependency on threads library
 set_target_properties(libsdl2 PROPERTIES
-        "IMPORTED_LOCATION" "${SDL2_BIN}/libSDL2.a"
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
         )
-target_include_directories(${PROJECT_NAME} PRIVATE ${SDL2_SRC}/include)
-add_dependencies(libsdl2 sdl2)
+
+# Setup main emulator executable
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${SDL_SOURCE_FILES})
+target_include_directories(${PROJECT_NAME} PRIVATE ${libsdl2_SRC}/include)
 #the libraries after libsdl2 are dependencies of libsdl2. It won't compile without these
-#thanks to https://github.com/SergNikitin/img_glypher/blob/master/CMakeLists.txt for helping me figure out how to resolve these errors
+#thanks to https://github.com/SergNikitin/img_glypher/blob/master/CMakeLists.txt for helping me figure out how to resolve these dependency errors
 target_link_libraries(${PROJECT_NAME} libsdl2 m dl sndio)
 
-
-#Setup testing with GTest and GMock libraries
-#big thanks to http://www.kaizou.org/2014/11/gtest-cmake/ for helping me get this set up
+#Allows CTest to be used (effectively enables the add_test() command)
 enable_testing()
-# We need thread support for GTest
-# Download and install GoogleTest
-ExternalProject_Add(
-        gtest
-        URL https://github.com/google/googletest/archive/master.zip
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
-        # Disable install step
-        INSTALL_COMMAND ""
-)
-# Get GTest source and binary directories from CMake project
-externalProject_get_property(gtest SOURCE_DIR BINARY_DIR)
-set(GTEST_SRC ${SOURCE_DIR})
-set(GTEST_BIN ${BINARY_DIR})
-# Create a libgtest target to be used as a dependency by test programs
-add_library(libgtest IMPORTED STATIC GLOBAL)
-# Set libgtest properties. libraries included from already built external projects need to specify their location with the below properties.
+
+# Create a library target for testing with GTest
+add_external_static_cmake_library(libgtest https://github.com/google/googletest/archive/master.zip googlemock/gtest/libgtest.a)
 set_target_properties(libgtest PROPERTIES
-        "IMPORTED_LOCATION" "${GTEST_BIN}/googlemock/gtest/libgtest.a"
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
         )
-# Create a libgmock target to be used as a dependency by test programs
+
+# Create a library target for testing with GMock
+# GMock was downloaded with GTest, so we don't need to go through the whole process of adding an external static library
+# Instead, we just point the new library target to the static library file for GMock
 add_library(libgmock IMPORTED STATIC GLOBAL)
-add_dependencies(libgmock gtest)
-# Set libgmock properties
+add_dependencies(libgmock libgtest)
 set_target_properties(libgmock PROPERTIES
-        "IMPORTED_LOCATION" "${GTEST_BIN}/googlemock/libgmock.a"
+        "IMPORTED_LOCATION" "${libgtest_BIN}/googlemock/libgmock.a"
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
         )
 
-
-#add_test allows you to execute test cases using "make test" i.e. the test target in the generated Makefile.
-#running this target only works from inside the build folder (Otherwise, there's no Makefile!)
+# Create a testcases executable target
+# add_test allows you to execute test cases using "make test" i.e. the test target in the generated Makefile.
 add_executable(testcases ${TESTING_SOURCE_FILES})
-# Set include directories
-target_include_directories(testcases PRIVATE "${GTEST_SRC}/googletest/include"
-        "${GTEST_SRC}/googlemock/include")
+target_include_directories(testcases PRIVATE "${libgtest_SRC}/googletest/include"
+        "${libgtest_SRC}/googlemock/include")
 target_link_libraries(testcases libgtest libgmock)
 add_test(EmulatorTests testcases)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(add_external_static_cmake_library)
 # use a memory leak dynamic (runtime) sanitizer to detect memory leaks.
 # Note: there seems to be memory leaks reported with some graphics and input drivers (ex: vmwgfx_dri - VMware's GL Driver, and libxi) that are out of this application's control
 set(CMAKE_CXX_STANDARD 11)
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fsanitize=leak -fno-omit-frame-pointer -Werror -Wall -Wextra")
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -g -fsanitize=leak -fno-omit-frame-pointer -Werror -Wall -Wextra")
 
 # Setup different source file variables
 set(SOURCE_FILES src/cpu/Cpu.cpp src/cpu/Cpu.h src/subsystems/display/IDisplay.h src/subsystems/input/IInputController.h src/storage/Memory.cpp src/storage/Memory.h src/exceptions/IndexOutOfBoundsException.h src/constants/Constants.h src/exceptions/InstructionUnimplementedException.h src/exceptions/BaseException.h src/constants/OpcodeBitmasks.h src/constants/Opcodes.h src/exceptions/UnimplementedException.h src/constants/OpcodeBitshifts.h src/utils/RandomUtil.cpp src/utils/RandomUtil.h src/io/FileByteReader.cpp src/io/FileByteReader.h src/exceptions/IOException.h src/exceptions/InitializationException.h src/subsystems/ISubsystemManager.h src/Chip8.cpp src/Chip8.h src/utils/SleepUtil.cpp src/utils/SleepUtil.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,26 +13,48 @@ set(SOURCE_FILES src/cpu/Cpu.cpp src/cpu/Cpu.h src/subsystems/display/IDisplay.h
 #keep source files that are dependent on SDL library separate in order to exclude from testcases build (and possibly other builds in the future).
 set(SDL_SOURCE_FILES src/subsystems/display/Display.cpp src/subsystems/display/Display.h src/subsystems/input/InputController.cpp src/subsystems/input/InputController.h src/subsystems/SdlSubsystemManager.cpp src/subsystems/SdlSubsystemManager.h src/main.cpp)
 set(TESTING_SOURCE_FILES testcases/CpuTest.cpp testcases/CpuTestFixture.cpp testcases/CpuTestFixture.h ${SOURCE_FILES} testcases/main.cpp testcases/mocks/MockDisplay.h testcases/mocks/MockInputController.h)
+set(ALL_SOURCE_FILES ${SOURCE_FILES} ${SDL_SOURCE_FILES} ${TESTING_SOURCE_FILES})
 
 #Setup main emulator executable
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${SDL_SOURCE_FILES})
 
 #makefile target to run clang-format on all built files
 #See more at: https://arcanis.me/en/2015/10/17/cppcheck-and-clang-format#sthash.nl8UE5nB.dpuf
-add_custom_target(clangformat COMMAND cd .. && /usr/bin/clang-format -style=file -i ${SOURCE_FILES} ${SDL_SOURCE_FILES} ${TESTING_SOURCE_FILES})
+add_custom_target(clangformat COMMAND cd .. && /usr/bin/clang-format -style=file -i ${ALL_SOURCE_FILES})
 
-#Setup SDL2 Library dependencies
-include(FindPkgConfig)
-pkg_search_module(SDL2 REQUIRED sdl2)
-include_directories(${SDL2_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES})
+#Required for both GTest and SDL2
+find_package(Threads REQUIRED)
+
+#module required for including external projects (libraries)
+include(ExternalProject)
+
+#Setup SDL2 Library Dependencies
+ExternalProject_Add(
+        sdl2
+        URL https://www.libsdl.org/tmp/SDL-2.0.5-11113.zip
+        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/sdl2
+        INSTALL_COMMAND ""
+)
+ExternalProject_Get_Property(sdl2 SOURCE_DIR)
+ExternalProject_Get_Property(sdl2 BINARY_DIR)
+set(SDL2_SRC ${SOURCE_DIR})
+set(SDL2_BIN ${BINARY_DIR})
+add_library(libsdl2 IMPORTED STATIC GLOBAL)
+set_target_properties(libsdl2 PROPERTIES
+        "IMPORTED_LOCATION" "${SDL2_BIN}/libSDL2.a"
+        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+        )
+target_include_directories(${PROJECT_NAME} PRIVATE ${SDL2_SRC}/include)
+add_dependencies(libsdl2 sdl2)
+#the libraries after libsdl2 are dependencies of libsdl2. It won't compile without these
+#thanks to https://github.com/SergNikitin/img_glypher/blob/master/CMakeLists.txt for helping me figure out how to resolve these errors
+target_link_libraries(${PROJECT_NAME} libsdl2 m dl sndio)
+
 
 #Setup testing with GTest and GMock libraries
 #big thanks to http://www.kaizou.org/2014/11/gtest-cmake/ for helping me get this set up
 enable_testing()
 # We need thread support for GTest
-find_package(Threads REQUIRED)
-include(ExternalProject)
 # Download and install GoogleTest
 ExternalProject_Add(
         gtest
@@ -42,12 +64,14 @@ ExternalProject_Add(
         INSTALL_COMMAND ""
 )
 # Get GTest source and binary directories from CMake project
-externalProject_get_property(gtest source_dir binary_dir)
+externalProject_get_property(gtest SOURCE_DIR BINARY_DIR)
+set(GTEST_SRC ${SOURCE_DIR})
+set(GTEST_BIN ${BINARY_DIR})
 # Create a libgtest target to be used as a dependency by test programs
 add_library(libgtest IMPORTED STATIC GLOBAL)
-# Set libgtest properties
+# Set libgtest properties. libraries included from already built external projects need to specify their location with the below properties.
 set_target_properties(libgtest PROPERTIES
-        "IMPORTED_LOCATION" "${binary_dir}/googlemock/gtest/libgtest.a"
+        "IMPORTED_LOCATION" "${GTEST_BIN}/googlemock/gtest/libgtest.a"
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
         )
 # Create a libgmock target to be used as a dependency by test programs
@@ -55,15 +79,16 @@ add_library(libgmock IMPORTED STATIC GLOBAL)
 add_dependencies(libgmock gtest)
 # Set libgmock properties
 set_target_properties(libgmock PROPERTIES
-        "IMPORTED_LOCATION" "${binary_dir}/googlemock/libgmock.a"
+        "IMPORTED_LOCATION" "${GTEST_BIN}/googlemock/libgmock.a"
         "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
         )
-# Set include directories
-include_directories("${source_dir}/googletest/include"
-        "${source_dir}/googlemock/include")
+
 
 #add_test allows you to execute test cases using "make test" i.e. the test target in the generated Makefile.
 #running this target only works from inside the build folder (Otherwise, there's no Makefile!)
 add_executable(testcases ${TESTING_SOURCE_FILES})
+# Set include directories
+target_include_directories(testcases PRIVATE "${GTEST_SRC}/googletest/include"
+        "${GTEST_SRC}/googlemock/include")
 target_link_libraries(testcases libgtest libgmock)
 add_test(EmulatorTests testcases)

--- a/Dependency-Setup.txt
+++ b/Dependency-Setup.txt
@@ -1,9 +1,0 @@
-#######Build Instructions########
-Ideally, the CMake script would handle downloading all the dependencies from other repositories, but I suck at CMake, so for now, this will have to do...
-
-Setting Up Dependencies For Ubuntu:
-
-1. Install SDL2
-- sudo apt install libsdl2-dev
-
-GTest and GMock are dependencies that should be downloaded and configured automatically by the CMake build script

--- a/cmake/Modules/add_external_static_cmake_library.cmake
+++ b/cmake/Modules/add_external_static_cmake_library.cmake
@@ -1,0 +1,40 @@
+# Big thanks to http://www.kaizou.org/2014/11/gtest-cmake/ for initially helping me use ExternalProject to setup libraries
+# Though, since reading this link, I have heavily modified the provided example to be more generic as demonstrated in the function below
+
+# module required for including external projects (libraries)
+include(ExternalProject)
+
+# Configures an external CMake project and creates a static library target for it
+# <url> should point to an archive of a CMake library with a CMakeLists.txt in the root directory
+# An external project will be created and populated by the contents at the given <url>
+# <static_library_path> should be a file path (or name) relative to the external project's binary directory pointing to the external project's built static library file
+# A new library target will be created with the name <libname>
+# Additionally, two variables will be initialized as "return values": <libname>_SRC and <libname>_BIN that point to
+# the source directory and the binary directory of the external project respectively
+function(add_external_static_cmake_library libname url static_library_path)
+    set(EXTERNAL_PROJECT_NAME ${libname}_EXTERNAL_PROJECT)
+    # Setup an external project for the library, and download it. put it in its own folder.
+    ExternalProject_Add(
+            ${EXTERNAL_PROJECT_NAME}
+            URL ${url}
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${libname}
+            INSTALL_COMMAND ""
+    )
+
+    # Get source and binary directories from external CMake project
+    ExternalProject_Get_Property(${EXTERNAL_PROJECT_NAME} SOURCE_DIR BINARY_DIR)
+
+    # SRC is set in the parent, and can be thought of kind of like a return value of this function
+    # BIN is set in the function scope and the parent scope, and is "returned" as well as used locally
+    set(${libname}_SRC ${SOURCE_DIR} PARENT_SCOPE)
+    set(${libname}_BIN ${BINARY_DIR} PARENT_SCOPE)
+    set(${libname}_BIN ${BINARY_DIR})
+
+    # Setup a library target (in this project) containing the built static library file from the external project.
+    # The key part here is setting IMPORTED_LOCATION to the location of the built external project's static library file.
+    add_library(${libname} IMPORTED STATIC GLOBAL)
+    set_target_properties(${libname} PROPERTIES
+            "IMPORTED_LOCATION" "${${libname}_BIN}/${static_library_path}"
+            )
+    add_dependencies(${libname} ${EXTERNAL_PROJECT_NAME})
+endfunction()

--- a/src/subsystems/display/IDisplay.h
+++ b/src/subsystems/display/IDisplay.h
@@ -1,8 +1,6 @@
 #ifndef CHIP_8_IDISPLAY_H
 #define CHIP_8_IDISPLAY_H
 
-#include <SDL.h>
-
 /**
  * An interface that must be implemented in order to allow the chip-8 emulator to draw any output onto the screen
  * The interface is fairly simple, allowing just about any platform to implement it as necessary, hopefully simplifying cross-platform

--- a/testcases/CpuTest.cpp
+++ b/testcases/CpuTest.cpp
@@ -2,7 +2,6 @@
 #include "../src/constants/OpcodeBitshifts.h"
 #include "../src/exceptions/IndexOutOfBoundsException.h"
 #include "CpuTestFixture.h"
-#include "gtest/gtest.h"
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Return;


### PR DESCRIPTION
This pull request refactors the Cmake script of the project to 

- configure separate debug and production builds (debug has different compiler flags)
- refactors adding external libraries into a separate function
- makes SDL2 download (and build) itself automatically instead of requiring the user to install it manually on their machine themselves