### PR TITLE
Fix a Segmentation Fault When Closing The Application

### DIFF
--- a/src/subsystems/display/Display.cpp
+++ b/src/subsystems/display/Display.cpp
@@ -62,8 +62,8 @@ void Display::setSdlPixel(int x, int y, uint32_t pixel) {
 }
 
 Display::~Display() {
-    SDL_DestroyWindow(window);
     SDL_FreeSurface(surface);
+    SDL_DestroyWindow(window);
     SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 


### PR DESCRIPTION
- In the Display module, the SDL surface has to be destroyed before the window is destroyed