### PR TITLE
Add Screen Scalability, Fix Bug In InputController

### DIFF
--- a/src/subsystems/display/Display.cpp
+++ b/src/subsystems/display/Display.cpp
@@ -43,7 +43,7 @@ Display::Display() {
         throwSdlError("SDL could not initialize video!");
     }
 
-    window = SDL_CreateWindow("Chip-8 Emulator", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, SCREEN_WIDTH, SCREEN_HEIGHT,
+    window = SDL_CreateWindow("Chip-8 Emulator", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, PHYSICAL_SCREEN_WIDTH, PHYSICAL_SCREEN_HEIGHT,
                               SDL_WINDOW_SHOWN);
     if (window == NULL) {
         // destructor won't be called if throwing from a constructor, so we should clean up after ourselves
@@ -58,7 +58,11 @@ Display::Display() {
 
 void Display::setSdlPixel(int x, int y, uint32_t pixel) {
     Uint32 *pixels = (Uint32 *)surface->pixels;
-    pixels[y * SCREEN_WIDTH + x] = pixel;
+    for (int row = 0; row < SCREEN_SCALE; row++) {
+        for (int col = 0; col < SCREEN_SCALE; col++) {
+            pixels[(y * PHYSICAL_SCREEN_WIDTH * SCREEN_SCALE) + (row * PHYSICAL_SCREEN_WIDTH) + (x * SCREEN_SCALE) + col] = pixel;
+        }
+    }
 }
 
 Display::~Display() {

--- a/src/subsystems/display/Display.h
+++ b/src/subsystems/display/Display.h
@@ -5,10 +5,8 @@
 #include "IDisplay.h"
 
 /**
- * A (very) simple IDisplay implementation using SDL. At the moment, this creates a very small window (because the chip-8's screen
- * resolution is small)
- * Ideally, this class should scale the size of a chip-8 pixel up to be larger than a pixel on the physical screen the emulator
- * renders on (which is hopefully larger than the chip-8's screen).
+ * A (very) simple IDisplay implementation using SDL. Creates a window that is SCREEN_SCALE * the CHIP-8's physical screen resolution.
+ * Ideally, this class should allow the user to specify an arbitrary scale, but the scale is currently hardcoded in SCREEN_SCALE.
  */
 namespace Chip8 {
 class Display : public IDisplay {
@@ -26,8 +24,11 @@ class Display : public IDisplay {
     void updateScreen() override;
 
    private:
+    static const int SCREEN_SCALE = 10;
     static const int SCREEN_WIDTH = 64;
     static const int SCREEN_HEIGHT = 32;
+    static const int PHYSICAL_SCREEN_WIDTH = SCREEN_WIDTH * SCREEN_SCALE;
+    static const int PHYSICAL_SCREEN_HEIGHT = SCREEN_HEIGHT * SCREEN_SCALE;
 
     SDL_Surface *surface = NULL;
     SDL_Window *window = NULL;

--- a/src/subsystems/input/InputController.h
+++ b/src/subsystems/input/InputController.h
@@ -35,7 +35,8 @@ class InputController : public IInputController {
 
     SDL_Keycode keyboardMappings[NUM_KEYS] = {SDLK_1, SDLK_2, SDLK_3, SDLK_4, SDLK_q, SDLK_w, SDLK_e, SDLK_r,
                                               SDLK_a, SDLK_s, SDLK_d, SDLK_f, SDLK_z, SDLK_x, SDLK_c, SDLK_v};
-    bool keyPressedStates[NUM_KEYS];
+    // initialize all the array values to zero
+    bool keyPressedStates[NUM_KEYS] = {};
     bool isExitPressed = false;
 
     /**


### PR DESCRIPTION
- Screen scale can now be set to x * the CHIP-8's physical screen size by changing a hardcoded variable
- Fixed bug where the key pressed states for CHIP-8 keys were uninitialized (filled with garbage memory). This caused random keys to be set to the pressed state when starting the emulator